### PR TITLE
Add "Standard ML of New Jersey" default installation path

### DIFF
--- a/SML.sublime-build
+++ b/SML.sublime-build
@@ -4,6 +4,6 @@
     "working_dir": "$file_path",
 
     "osx": {
-        "path": "/opt/local/bin:/usr/bin:/opt/local/sbin:/bin:/usr/sbin:/usr/local/bin"
+        "path": "/opt/local/bin:/usr/bin:/opt/local/sbin:/bin:/usr/sbin:/usr/local/bin:/usr/local/smlnj-110.75/bin"
     }
 }


### PR DESCRIPTION
The defaul root installation directory of the "Standard ML of New Jersey" is
/usr/local/smlnj, the `sml` command is found under the "bin" directory wich is
not automatically found by SublimeText.

Ref: http://www.smlnj.org/dist/working/110.75/NOTES/MACOSXINSTALL

The installer is recommend by the [Programming Languages course in Coursera](https://www.coursera.org/course/proglang) and the course forum has a lot of request for SML support in SublimeText.
