### PR TITLE
Windows support added for build system

### DIFF
--- a/SML.sublime-build
+++ b/SML.sublime-build
@@ -6,4 +6,8 @@
     "osx": {
         "path": "/opt/local/bin:/usr/bin:/opt/local/sbin:/bin:/usr/sbin:/usr/local/bin"
     }
+
+    "windows": {
+        "cmd": ["sml.bat", "$file"]
+    }
 }


### PR DESCRIPTION
I'm just another user using SML in SublimeText under Windows, so I just added the support for Windows.
