### PR TITLE
Add indentation rules; use tabs in all snippets

### DIFF
--- a/Indentation Rules.tmPreferences
+++ b/Indentation Rules.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Indentation Rules</string>
+  <key>scope</key>
+  <string>source.sml</string>
+  <key>settings</key>
+  <dict>
+    <key>decreaseIndentPattern</key>
+    <string>^\s*\b(end|in)\b</string>
+    <key>increaseIndentPattern</key>
+    <string>^[^%]*(\b(fun|let|in)\b(?!.*\b(end)\b.*))</string>
+  </dict>
+  <key>uuid</key>
+  <string>78cd75f7-310b-4a6a-86ac-b015cdd714a1</string>
+</dict>
+</plist>

--- a/Indentation Rules.tmPreferences
+++ b/Indentation Rules.tmPreferences
@@ -11,7 +11,7 @@
     <key>decreaseIndentPattern</key>
     <string>^\s*\b(end|in)\b</string>
     <key>increaseIndentPattern</key>
-    <string>^[^%]*(\b(fun|let|in)\b(?!.*\b(end)\b.*))</string>
+    <string>^(?!\(\*).*(\b(fun|let|in)\b(?!.*\b(end)\b.*))</string>
   </dict>
   <key>uuid</key>
   <string>78cd75f7-310b-4a6a-86ac-b015cdd714a1</string>

--- a/Indentation Rules.tmPreferences
+++ b/Indentation Rules.tmPreferences
@@ -9,9 +9,9 @@
   <key>settings</key>
   <dict>
     <key>decreaseIndentPattern</key>
-    <string>^\s*\b(end|in)\b</string>
+    <string>^\s*\b(and|else|end|in)\b</string>
     <key>increaseIndentPattern</key>
-    <string>^(?!\(\*).*(\b(fun|let|in)\b(?!.*\b(end)\b.*))</string>
+    <string>^(?!\(\*).*(\b(and|case|do|else|handle|in|let|local|fun|functor|sig|struct|then|with)\b(?!.*\b(end)\b.*))</string>
   </dict>
   <key>uuid</key>
   <string>78cd75f7-310b-4a6a-86ac-b015cdd714a1</string>

--- a/sml-case.sublime-snippet
+++ b/sml-case.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[case ${1:expression} of
-    ${2:pattern1} => ${3:body1}
-  | ${4:pattern2} => ${5:body2}
+	${2:pattern1} => ${3:body1}
+	| ${4:pattern2} => ${5:body2}
 ]]></content>
     <tabTrigger>case</tabTrigger>
     <scope>source.sml</scope>

--- a/sml-datatype.sublime-snippet
+++ b/sml-datatype.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[datatype ${1:name} = 
-    ${2:name1} of ${3:type1} 
-  | ${4:name2} of ${5:type2}]]></content>
+	${2:name1} of ${3:type1} 
+	| ${4:name2} of ${5:type2}]]></content>
     <tabTrigger>datatype</tabTrigger>
     <scope>source.sml</scope>
     <description>SML 'datatype' declaration</description>

--- a/sml-fn.sublime-snippet
+++ b/sml-fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn ${1:arguments} => 
-    ${2:body}
+	${2:body}
 ]]></content>
     <tabTrigger>fn</tabTrigger>
     <scope>source.sml</scope>

--- a/sml-functor.sublime-snippet
+++ b/sml-functor.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[functor ${1:name} (${2:argument}) = 
 struct
-    ${3:(* Body *)}
+	${3:(* Body *)}
 end
 ]]></content>
     <tabTrigger>functor</tabTrigger>

--- a/sml-let.sublime-snippet
+++ b/sml-let.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
     <content><![CDATA[let
-    val ${1:name} = ${2:value}
+	val ${1:name} = ${2:value}
 in
-    ${3:body}
+	${3:body}
 end
 ]]></content>
     <tabTrigger>let</tabTrigger>

--- a/sml-signature.sublime-snippet
+++ b/sml-signature.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[signature ${1:name} = 
 sig
-    ${2:(* Body *)}
+	${2:(* Body *)}
 end
 ]]></content>
     <tabTrigger>signature</tabTrigger>

--- a/sml-structure.sublime-snippet
+++ b/sml-structure.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[structure ${1:name} = 
 struct
-    ${2:(* Body *)}
+	${2:(* Body *)}
 end
 ]]></content>
     <tabTrigger>structure</tabTrigger>


### PR DESCRIPTION
Previously for some reason auto indent doesn't work if I manually typed my code. So I added indentation rules to implement that.

Also for the snippets, in CDATA section I replaced the hard coded spaces at the beginning of a new line with a tab. So the actual indentation matches with users' indentation settings.
